### PR TITLE
Enable deployment workflow on closed pull requests to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,10 @@ on:
       - 'feature/**'
       - 'develop'
       - 'main'
+  pull_request:
+    branches:
+      - main
+    types: [closed]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
This pull request ensures that the deployment workflow is automatically triggered when a pull request directed towards the `main` branch is closed. It enhances the CI/CD process by streamlining deployments.